### PR TITLE
fix: navbar 预留状态栏高度

### DIFF
--- a/packages/vantui/src/components/nav-bar/wxs.ts
+++ b/packages/vantui/src/components/nav-bar/wxs.ts
@@ -1,11 +1,13 @@
-import { style } from '../wxs/style'
+import { style } from '../wxs/style';
 
 function barStyle(data: any) {
   return style({
     'z-index': data.zIndex,
-    'padding-top': data.fromTop + 'px',
-    height: data.height + 'px',
-  })
+    'padding-top': data.safeAreaInsetTop
+      ? data.statusBarHeight + 'px'
+      : data.fromTop + 'px',
+    height: data.height + 'px'
+  });
 }
 
-export { barStyle }
+export { barStyle };

--- a/packages/vantui/src/components/nav-bar/wxs.ts
+++ b/packages/vantui/src/components/nav-bar/wxs.ts
@@ -1,4 +1,4 @@
-import { style } from '../wxs/style';
+import { style } from '../wxs/style'
 
 function barStyle(data: any) {
   return style({
@@ -10,4 +10,4 @@ function barStyle(data: any) {
   });
 }
 
-export { barStyle };
+export { barStyle }


### PR DESCRIPTION
使用 navbar 的时候发现不管有没有设置 safeAreaInsetTop 都没有为状态栏预留高度，于是检查源码发现 navbar 状态栏高度的逻辑是引用同目录下的 wxs.ts ，但里面并没有对 navbar 传入的参数进行逻辑判断，便作此修改。