### PR TITLE
fix: tabbarprops active type

### DIFF
--- a/packages/vantui/types/tabbar.d.ts
+++ b/packages/vantui/types/tabbar.d.ts
@@ -2,7 +2,7 @@ import { ComponentClass, ReactNode } from 'react'
 import { StandardProps } from '@tarojs/components'
 
 export interface TabbarProps extends StandardProps {
-  active?: number
+  active?: string | number
   activeColor?: string
   inactiveColor?: string
   fixed?: boolean


### PR DESCRIPTION
TabbarItem的name属性是string | number，Tabbar的active属性是number，虽然active写string代码也能正常运行，但ts会报红，挺蛋疼的，所以就修复了下