### PR TITLE
fix: 发出下拉刷新请求时才显示loadingText

### DIFF
--- a/packages/vantui/src/power-scroll-view/index.tsx
+++ b/packages/vantui/src/power-scroll-view/index.tsx
@@ -108,6 +108,7 @@ export function PowerScrollView<T extends number | undefined>(
   const startTop = useRef(0)
 
   const [finished, setFinished] = useState<boolean>(_finished || false)
+  const [isLoadingMore, setIsLoadingMore] = useState<boolean>(false)
   const currentCount = current ?? Array.from(children as any).length
   const listCount = useRef(0)
   useEffect(() => {
@@ -383,6 +384,7 @@ export function PowerScrollView<T extends number | undefined>(
     if (isBanLoad()) return
     try {
       loadingRef.current = true
+      setIsLoadingMore(true)
       paginationRef.current.page += 1
       const event = total === undefined ? currentCount : paginationRef.current
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -395,6 +397,7 @@ export function PowerScrollView<T extends number | undefined>(
       // 这里要主动触发刷新
       // throw e
     } finally {
+      setIsLoadingMore(false)
       loadingRef.current = false
     }
   }, [currentCount, isBanLoad, onScrollToLower, total])
@@ -497,7 +500,11 @@ export function PowerScrollView<T extends number | undefined>(
       return renderFinishedText
     }
 
-    return renderLoadingText
+    if(isLoadingMore) {
+      return renderLoadingText
+    }
+
+    return <></>
   }, [
     finished,
     currentCount,
@@ -507,6 +514,7 @@ export function PowerScrollView<T extends number | undefined>(
     emptyImage,
     renderErrorText,
     renderFinishedText,
+    isLoadingMore
   ])
 
   const renderStatusBody = (


### PR DESCRIPTION
遇到的问题：当数据总数不足以撑满 scroolView 时，会一直显示加载中（实际并没有触发onScrollToLower）
![image](https://user-images.githubusercontent.com/36886269/157444830-a7db67cd-276a-4639-9149-96fa00006beb.png)
问题原因分析：默认显示加载中，但是实际上并没有在加载
解决方法：在触发 doLoadMore 时才显示加载中