### PR TITLE
fix: field input输入的内容在行内没有垂直居中的问题

### DIFF
--- a/packages/vantui/src/field/index.less
+++ b/packages/vantui/src/field/index.less
@@ -46,6 +46,12 @@
     input {
       font-size: @field-font-size;
     }
+    
+    input {
+      .theme(height, '@cell-line-height');
+      .theme(min-height, '@cell-line-height');
+      .theme(line-height, '@cell-line-height');
+    }
 
     .theme(color, '@field-input-text-color');
     .theme(height, '@cell-line-height');


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/12181423/180715119-e38f6f5e-2741-49d2-84a3-5f2a1717db17.png)

问题的原因是 `weui-input` 设置了 `height`，这个 `height` 应该根据我们自己组件的 `--cell-line-height` 值进行相应的调整