### PR TITLE
fix: navbar 在小程序中不能动态的修改样式问题

### DIFF
--- a/packages/vantui/src/nav-bar/mini.tsx
+++ b/packages/vantui/src/nav-bar/mini.tsx
@@ -98,9 +98,7 @@ export function MiniNavBar(props: MiniNavBarProps) {
 
   return (
     <>
-      {fixed && placeholder && (
-        <View style={getMiniNavbarHeight}></View>
-      )}
+      {fixed && placeholder && (<View style={getMiniNavbarHeight}></View>)}
       <View
         className={
           utils.bem('mini-nav-bar', {

--- a/packages/vantui/src/nav-bar/mini.tsx
+++ b/packages/vantui/src/nav-bar/mini.tsx
@@ -1,5 +1,5 @@
 import { navigateBack, reLaunch, getCurrentPages } from '@tarojs/taro'
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
 import { View } from '@tarojs/components'
 import * as utils from '../wxs/utils'
 import { Icon } from '../icon'
@@ -52,7 +52,7 @@ export function MiniNavBar(props: MiniNavBarProps) {
   const [homeButton, setHomeButton] = useState(false)
 
   useEffect(
-    function () {
+    () => {
       const pages = getCurrentPages()
       if (pages.length >= 1) {
         const ins: any = pages[pages.length - 1]
@@ -68,7 +68,7 @@ export function MiniNavBar(props: MiniNavBarProps) {
     [homeUrl],
   )
 
-  useEffect(function () {
+  useEffect(() => {
     const sysInfo = getSystemInfoSync()
     const menuInfo = getMenuButtonBoundingClientRect()
     if (sysInfo && menuInfo) {
@@ -83,25 +83,24 @@ export function MiniNavBar(props: MiniNavBarProps) {
     }
   }, [])
 
-  const getMiniNavbarHeight = useCallback(
-    function () {
-      return utils.style([
-        computed.barStyle({
-          zIndex,
-          fromTop,
-          height,
-          fromLeft,
-        }) +
-          '; ' +
-          style,
-      ])
-    },
-    [zIndex, fromTop, height, fromLeft, style],
-  )
+  const getMiniNavbarHeight = useMemo(() => {
+    return utils.style([
+      computed.barStyle({
+        zIndex,
+        fromTop,
+        height,
+        fromLeft,
+      }) +
+      '; ' +
+      style,
+    ]);
+  }, [zIndex, fromTop, height, fromLeft, style])
 
   return (
     <>
-      {fixed && placeholder && <View style={getMiniNavbarHeight()}></View>}
+      {fixed && placeholder && (
+        <View style={getMiniNavbarHeight}></View>
+      )}
       <View
         className={
           utils.bem('mini-nav-bar', {
@@ -111,7 +110,7 @@ export function MiniNavBar(props: MiniNavBarProps) {
           (border ? 'van-hairline--bottom' : '') +
           ` ${className || ''}`
         }
-        style={getMiniNavbarHeight()}
+        style={getMiniNavbarHeight}
         {...others}
       >
         <View className="van-mini-nav-bar__content">


### PR DESCRIPTION
需求：根据页面滚动高度来调整`Navbar`的背景色和透明度。

修复的问题：原来 `getMiniNavbarHeight` 是采用 `useCallback` 来计算并返回结果，这个只有在第一次调用的时候才会触发，后期参数变化了，并没有触发的时机所以将 `useCallback` 替换成 `useMemo` ，它仅会在某个依赖项改变时才重新计算 `memoized` 值，这样就会根据用户动态传入的参数进行修改 `Navbar` 的样式。