### PR TITLE
fix: navbar 在h5中不能动态的修改样式问题

### DIFF
--- a/packages/vantui/src/nav-bar/index.tsx
+++ b/packages/vantui/src/nav-bar/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { View } from '@tarojs/components'
 import * as utils from '../wxs/utils'
 import { getSystemInfoSync } from '../common/utils'
@@ -28,32 +28,30 @@ export function NavBar(props: NavBarProps) {
     ...others
   } = props
 
-  useEffect(function () {
+  useEffect(() => {
     let { statusBarHeight = 22 } = getSystemInfoSync()
     if (isNaN(statusBarHeight)) statusBarHeight = 22
     setStatusBarHeight(statusBarHeight)
   }, [])
 
-  const getNavBarStyle = useCallback(
-    function () {
-      return utils.style([
-        computed.barStyle({
-          zIndex,
-          statusBarHeight,
-          safeAreaInsetTop,
-          height: 50,
-        }) +
-          '; ' +
-          style,
-      ])
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [zIndex, statusBarHeight, safeAreaInsetTop],
-  )
+  const getNavBarStyle = useMemo(() => {
+    return utils.style([
+      computed.barStyle({
+        zIndex,
+        statusBarHeight,
+        safeAreaInsetTop,
+        height: 50,
+      }) +
+      '; ' +
+      style,
+    ]);
+  }, [zIndex, statusBarHeight, safeAreaInsetTop])
 
   return (
     <>
-      {fixed && placeholder && <View style={getNavBarStyle()}></View>}
+      {fixed && placeholder && (
+        <View style={getNavBarStyle}></View>
+      )}
       <View
         className={
           utils.bem('nav-bar', {
@@ -63,7 +61,7 @@ export function NavBar(props: NavBarProps) {
           (border ? 'van-hairline--bottom' : '') +
           ` ${className || ''}`
         }
-        style={getNavBarStyle()}
+        style={getNavBarStyle}
         {...others}
       >
         <View className="van-nav-bar__content">

--- a/packages/vantui/src/nav-bar/index.tsx
+++ b/packages/vantui/src/nav-bar/index.tsx
@@ -49,9 +49,7 @@ export function NavBar(props: NavBarProps) {
 
   return (
     <>
-      {fixed && placeholder && (
-        <View style={getNavBarStyle}></View>
-      )}
+      {fixed && placeholder && (<View style={getNavBarStyle}></View>)}
       <View
         className={
           utils.bem('nav-bar', {


### PR DESCRIPTION
需求：根据页面滚动高度来调整`Navbar`的背景色和透明度。


修复的问题：原来 `getMiniNavbarHeight` 是采用 `useCallback` 来计算并返回结果，这个只有在第一次调用的时候才会触发，后期参数变化了，并没有触发的时机所以将 `useCallback` 替换成 `useMemo` ，它仅会在某个依赖项改变时才重新计算 `memoized` 值，这样就会根据用户动态传入的参数进行修改 `Navbar` 的样式。