### PR TITLE
fix: 折叠面板折叠动画时高度异常问题

### DIFF
--- a/packages/vantui/src/collapse-item/animate.ts
+++ b/packages/vantui/src/collapse-item/animate.ts
@@ -72,13 +72,13 @@ function useAnimation(expanded: any, mounted: any, height: any, setState: any) {
   }
 }
 export function setContentAnimate(
-  context: any,
+  selector: any,
   expanded: any,
   mounted: any,
   setState: any,
   ref?: any,
 ) {
-  getRect(context, '.van-collapse-item__content')
+  getRect(null, selector)
     .then((rect: any) => {
       return process.env.TARO_ENV === 'h5'
         ? ref.current.clientHeight

--- a/packages/vantui/src/collapse-item/index.tsx
+++ b/packages/vantui/src/collapse-item/index.tsx
@@ -69,6 +69,7 @@ export function CollapseItem(
   }, [])
 
   const refDom = useRef(null)
+  const refRandomClass = useRef(`selector-${`${Math.random()}`.slice(-8)}`)
 
   const updateExpanded = useCallback(() => {
     if (!parent) {
@@ -81,7 +82,7 @@ export function CollapseItem(
       ? value === currentName
       : (value || []).some((name: any) => name === currentName)
     if (expanded !== state.expanded) {
-      setContentAnimate(null, expanded, ref.current.mounted, setState, refDom)
+      setContentAnimate(`.${refRandomClass.current}`, expanded, ref.current.mounted, setState, refDom)
     }
     setState((state) => {
       return {
@@ -155,7 +156,7 @@ export function CollapseItem(
         }
         animation={state.animation}
       >
-        <View className="van-collapse-item__content content-class" ref={refDom}>
+        <View className={`van-collapse-item__content content-class ${refRandomClass.current}`} ref={refDom}>
           {children}
         </View>
       </View>


### PR DESCRIPTION
问题：折叠面板所有动画，会以第一个面板内容的高度做动画，当有面板内容高度小于第一个内容时，这个面板的动画会有抽搐效果。

原因：原版中使用 `this` 获取 `context`保障获取到正确的元素高度，当前 `React` 版本中函数式写法无法使用 `this` 传递组件实例，传递了 `null` 之后所有子面板查询到的元素都是第一个面板。

解决思路：尝试使用 `refDOM`传递父元素也无法正确获取到面板元素，因此使用了随机类名以便强选择到正确元素。既然无法获取当前组件实例，便将 `setContentAnimate` 的第一个入参 `context` 改为了 `selector` 。