### PR TITLE
fix: add Date type for value prop in DateTimePicker widget

### DIFF
--- a/packages/vantui-doc/src/datetime-picker/README.md
+++ b/packages/vantui-doc/src/datetime-picker/README.md
@@ -16,7 +16,7 @@ import { DatetimePicker } from '@antmjs/vantui'
 
 ### 选择完整时间
 
-`value` 为时间戳。
+`value` 为Date对象。
 
 ```jsx
 function Demo() {
@@ -49,7 +49,7 @@ function Demo() {
 
 ### 选择日期（年月日）
 
-`value` 为时间戳，通过传入 `formatter` 函数对选项文字进行处理。
+`value` 为Date对象，通过传入 `formatter` 函数对选项文字进行处理。
 
 ```jsx
 function Demo() {
@@ -95,7 +95,7 @@ function Demo() {
 
 ### 选择日期（年月）
 
-`value` 为时间戳。
+`value` 为Date对象。
 
 ```jsx
 function Demo() {

--- a/packages/vantui/types/datetime-picker.d.ts
+++ b/packages/vantui/types/datetime-picker.d.ts
@@ -16,7 +16,7 @@ export interface DatetimePickerProps
    * @description 选项的值
    * @default null
    */
-  value?: string | number
+  value?: string | number | Date
   /**
    * @description 对选项数组进行过滤，实现自定义时间间隔
    */


### PR DESCRIPTION
**BUG 描述**

`DateTimePicker`的typing中，当`type`为`datetime`, `date`, `year-month`时，`value`应该接受`Date`类型

**修改方案**

修改`datetime-picker.d.ts`，`value`增加`Date`类型，同时修改说明文档