### PR TITLE
feat: 修改 Layout 布局中 横向和竖向 间隔

### DIFF
--- a/packages/vantui/src/col/index.tsx
+++ b/packages/vantui/src/col/index.tsx
@@ -1,4 +1,5 @@
 import { View } from '@tarojs/components'
+import classNames from 'classnames'
 import * as utils from '../wxs/utils'
 import { ColProps } from '../../types/col'
 import * as computed from './wxs'
@@ -16,14 +17,11 @@ export function Col(props: ColProps): JSX.Element {
 
   return (
     <View
-      className={
-        '' +
-        utils.bem('col', [span]) +
-        ' ' +
-        (offset ? 'van-col--offset-' + offset : '') +
-        ' ' +
-        className
-      }
+      className={classNames(
+        utils.bem('col', [span]),
+        offset ? 'van-col--offset-' + offset : '',
+        className,
+      )}
       style={utils.style([
         computed.rootStyle({
           gutter,

--- a/packages/vantui/src/col/wxs.ts
+++ b/packages/vantui/src/col/wxs.ts
@@ -1,15 +1,62 @@
 import { style } from '../wxs/utils'
 import { addUnit } from '../wxs/add-unit'
 
-function rootStyle(data: any) {
+function rootStyle(data: {
+  gutter: number | string | [number, number] | [string, string] | undefined
+}) {
+  const styles: Record<string, string | number> = {}
+  let hor: string | number | null = null
+  let ver: string | number | null = null
+
   if (!data.gutter) {
     return ''
   }
 
-  return style({
-    'padding-right': addUnit(data.gutter / 2),
-    'padding-left': addUnit(data.gutter / 2),
-  })
+  if (Array.isArray(data.gutter)) {
+    if (data.gutter.length > 0) {
+      hor = data.gutter[0]
+    }
+    if (data.gutter.length > 1) {
+      ver = data.gutter[1]
+    }
+  } else {
+    hor = data.gutter
+  }
+
+  const judge = (val: string | number, pos: 'x' | 'y') => {
+    let unit = ''
+    let value = 0
+
+    if (typeof val == 'string' && val.constructor == String) {
+      const matches = /^([\.\-\d]+)([^\d]*)$/gi.exec(val)
+      if (matches && matches.length > 0) {
+        value = Number(matches[1])
+        if (matches[2]) {
+          unit = matches[2] === 'px' ? '' : matches[2]
+        }
+      }
+    } else if (typeof val == 'number' && val.constructor == Number) {
+      value = val
+    }
+
+    const v = addUnit(value / 2 + unit)
+
+    if (pos === 'x') {
+      styles['padding-right'] = v
+      styles['padding-left'] = v
+    }
+
+    if (pos === 'y') {
+      styles['padding-top'] = v
+      styles['padding-bottom'] = v
+    }
+  }
+
+  if (hor != null) judge(hor, 'x')
+  if (ver != null) judge(ver, 'y')
+
+  const result = style(styles)
+  return result
 }
 
 export { rootStyle }

--- a/packages/vantui/src/row/index.less
+++ b/packages/vantui/src/row/index.less
@@ -5,3 +5,7 @@
     content: '';
   }
 }
+
+.van-row-wrapper {
+  overflow: hidden;
+}

--- a/packages/vantui/src/row/index.tsx
+++ b/packages/vantui/src/row/index.tsx
@@ -1,4 +1,7 @@
 import { View } from '@tarojs/components'
+import React, { useMemo } from 'react'
+import toArray from 'rc-util/lib/Children/toArray'
+import classNames from 'classnames'
 import * as utils from '../wxs/utils'
 import { RowProps } from '../../types/col'
 import * as computed from './wxs'
@@ -6,18 +9,28 @@ import * as computed from './wxs'
 export function Row(props: RowProps): JSX.Element {
   const { gutter, children, className, style, ...others } = props
 
+  const newChildren: React.ReactElement[] = useMemo(() => {
+    return toArray(children).map((node: React.ReactElement) =>
+      React.cloneElement(node, {
+        gutter: gutter,
+      }),
+    )
+  }, [children, gutter])
+
   return (
-    <View
-      className={`van-row  ${className}`}
-      style={utils.style([
-        computed.rootStyle({
-          gutter,
-        }),
-        style,
-      ])}
-      {...others}
-    >
-      {children}
+    <View className="van-row-wrapper">
+      <View
+        className={classNames(`van-row`, className)}
+        style={utils.style([
+          computed.rootStyle({
+            gutter,
+          }),
+          style,
+        ])}
+        {...others}
+      >
+        {newChildren}
+      </View>
     </View>
   )
 }

--- a/packages/vantui/src/row/wxs.ts
+++ b/packages/vantui/src/row/wxs.ts
@@ -1,15 +1,62 @@
 import { style } from '../wxs/utils'
 import { addUnit } from '../wxs/add-unit'
 
-function rootStyle(data: any) {
+function rootStyle(data: {
+  gutter: number | string | [number, number] | [string, string] | undefined
+}) {
+  const styles: Record<string, string | number> = {}
+  let hor: string | number | null = null
+  let ver: string | number | null = null
+
   if (!data.gutter) {
     return ''
   }
 
-  return style({
-    'margin-right': addUnit(-data.gutter / 2),
-    'margin-left': addUnit(-data.gutter / 2),
-  })
+  if (Array.isArray(data.gutter)) {
+    if (data.gutter.length > 0) {
+      hor = data.gutter[0]
+    }
+    if (data.gutter.length > 1) {
+      ver = data.gutter[1]
+    }
+  } else {
+    hor = data.gutter
+  }
+
+  const judge = (val: string | number, pos: 'x' | 'y') => {
+    let unit = ''
+    let value = 0
+
+    if (typeof val == 'string' && val.constructor == String) {
+      const matches = /^([\.\-\d]+)([^\d]*)$/gi.exec(val)
+      if (matches && matches.length > 0) {
+        value = Number(matches[1])
+        if (matches[2]) {
+          unit = matches[2] === 'px' ? '' : matches[2]
+        }
+      }
+    } else if (typeof val == 'number' && val.constructor == Number) {
+      value = val
+    }
+
+    const v = addUnit(-value / 2 + unit)
+
+    if (pos === 'x') {
+      styles['margin-right'] = v
+      styles['margin-left'] = v
+    }
+
+    if (pos === 'y') {
+      styles['margin-top'] = v
+      styles['margin-bottom'] = v
+    }
+  }
+
+  if (hor != null) judge(hor, 'x')
+  if (ver != null) judge(ver, 'y')
+
+  const result = style(styles)
+  return result
 }
 
 export { rootStyle }

--- a/packages/vantui/types/col.d.ts
+++ b/packages/vantui/types/col.d.ts
@@ -23,9 +23,9 @@ export interface ColProps extends StandardProps {
  */
 export interface RowProps extends StandardProps {
   /**
-   * @description 列元素之间的间距（单位为 px）
+   * @description 列元素之间的间距（如查输入数字：单位为 px，如果输入字符串，可使用单位rpx）
    */
-  gutter?: number | string
+  gutter?: number | string | [number, number] | [string, string]
   children: React.ReactNode
 }
 


### PR DESCRIPTION
**原存在情况：**
Row 组件中 gutter 只能设置横向，  且没有向子Col 组件中传入 父级 gutter

**现修改情况：**
在Row组中 gutter 输入类型添加 数字数组 和 字符数组传入， 并允许使用 rpx 单位， 如：

`        <Row gutter={['50rpx', '50rpx']}>
          <Col span={12}>
            <View>hahaahha</View>
          </Col>
          <Col span={12}>
            <View>hahaahha</View>
          </Col>
          <Col span={12}>
            <View>hahaahha</View>
          </Col>
          <Col span={12}>
            <View>hahaahha</View>
          </Col>
          <Col span={12}>
            <View>hahaahha</View>
          </Col>
          <Col span={12}>
            <View>hahaahha</View>
          </Col>
        </Row>`