### PR TITLE
fix: 修改FormItem组件包裹label组件为View，解决label为非text的React.ReactNode时无法正常展示

### DIFF
--- a/packages/vantui-cli/package.json
+++ b/packages/vantui-cli/package.json
@@ -19,8 +19,8 @@
     "antmjs"
   ],
   "scripts": {
-    "watch": "rm -rf build && npx tsc -p tsconfig.cjs.json --watch --sourceMap",
-    "build": "rm -rf build && npx tsc -p tsconfig.cjs.json",
+    "watch": "rimraf build && npx tsc -p tsconfig.cjs.json --watch --sourceMap",
+    "build": "rimraf build && npx tsc -p tsconfig.cjs.json",
     "test:watch": "",
     "test": ""
   },

--- a/packages/vantui/src/form-item/label.tsx
+++ b/packages/vantui/src/form-item/label.tsx
@@ -31,7 +31,7 @@ export default function Label(props: Iprops) {
           </>
         ) : null}
       </View>
-      <Text>{label}</Text>
+      <View>{label}</View>
     </View>
   )
 }


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
小程序的text只能嵌套自身，项目中label为非text的React.ReactNode时无法正常展示

**这个 PR 满足以下需求:**

- [ ] 提交到 main 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] 快手小程序
- [ ] QQ 轻应用
- [ ] Web 平台（H5）

**其它需要 Reviewer 或社区知晓的内容：**
