### PR TITLE
fix: 修复nav-bar不合适的获取statusBarHeight时机导致导航栏高度跳动

### DIFF
--- a/packages/vantui/src/nav-bar/index.tsx
+++ b/packages/vantui/src/nav-bar/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo } from 'react'
 import { View } from '@tarojs/components'
 import * as utils from '../wxs/utils'
 import { getSystemInfoSync } from '../common/utils'
@@ -7,7 +7,6 @@ import { Icon } from '../icon'
 import * as computed from './wxs'
 
 export function NavBar(props: NavBarProps) {
-  const [statusBarHeight, setStatusBarHeight] = useState(22)
   const {
     fixed,
     placeholder,
@@ -28,10 +27,12 @@ export function NavBar(props: NavBarProps) {
     ...others
   } = props
 
-  useEffect(() => {
-    let { statusBarHeight = 22 } = getSystemInfoSync()
-    if (isNaN(statusBarHeight)) statusBarHeight = 22
-    setStatusBarHeight(statusBarHeight)
+  const statusBarHeight = useMemo(() => {
+    const { statusBarHeight: _statusBarHeight } = getSystemInfoSync()
+    if (isNaN(_statusBarHeight)) {
+      return 22
+    }
+    return _statusBarHeight
   }, [])
 
   const getNavBarStyle = useMemo(() => {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
修复了nav-bar组件使用state保存statusBarHeight并使用useEffect更新值导致部分机型例如14pro导航栏高度跳动。

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 main 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] 快手小程序
- [x] QQ 轻应用
- [x] Web 平台（H5）

**其它需要 Reviewer 或社区知晓的内容：**
