### PR TITLE
fix(dialog): 修复 dialog 组件自定义 title 时 h5 端报错问题

### DIFF
--- a/packages/vantui/src/dialog/index.tsx
+++ b/packages/vantui/src/dialog/index.tsx
@@ -207,7 +207,7 @@ export function Dialog(props: DialogProps) {
                 theme,
                 messageAlign,
                 {
-                  hasTitle: title,
+                  hasTitle: !!title,
                 },
               ])}
             >


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 main 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] 快手小程序
- [ ] QQ 轻应用
- [x] Web 平台（H5）

**其它需要 Reviewer 或社区知晓的内容：**

当自定义标题时，title 为 ReactNode，传入 bem 后 `JSON.stringify` 序列化会导致错误 。

<img width="901" alt="85c5c6d3-4b43-4c3f-a3b5-e7f85dc51753" src="https://github.com/AntmJS/vantui/assets/19278877/dd980545-ab07-43ae-9191-dfbd519610c3">

复现： `<Dialog title={<View>自定义</View>} />` 
