### PR TITLE
fix: 修改日历组件滚动bug

### DIFF
--- a/packages/vantui/src/calendar/index.tsx
+++ b/packages/vantui/src/calendar/index.tsx
@@ -96,6 +96,7 @@ function Index(
   const [scrollIntoView, setScrollIntoView] = useState('')
   const contentObserver = useRef<any>()
   const [compIndex, setComindex] = useState(0)
+  const [isInitial, setIsInitial] = useState(true)
 
   useEffect(function () {
     setComindex(init++)
@@ -177,7 +178,9 @@ function Index(
   const reset = useCallback(
     function () {
       setCurrentDate(getInitialDate(defaultDate))
-      scrollIntoViewFn()
+      setTimeout(() => {
+        scrollIntoViewFn()
+      }, 66)
     },
     [getInitialDate, scrollIntoViewFn, defaultDate],
   )
@@ -387,6 +390,7 @@ function Index(
     function () {
       if (defaultDate) {
         setCurrentDate(getInitialDate(defaultDate || new Date().getTime()))
+        setIsInitial(false)
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -409,7 +413,7 @@ function Index(
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [poppable, show],
+    [poppable, show, isInitial],
   )
 
   useEffect(


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
修复日历组件平铺模式下，设置`defaultDate` 时，无法滚动到默认日期下。

主要是两个闭包陷阱吧。 
第一个reset 方法，`setCurrentDate` 后，在 `scrollIntoViewFn` 中其实还没拿到对应的currentDate 值
第二个是在平铺模式下即`poppable = false`， useLayoutEffect `setCurrentDate` 后，下面的依赖于 `poppable 和`show`的useEffect 应该重新执行吧

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ ] 提交到 main 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] 快手小程序
- [x] QQ 轻应用
- [x] Web 平台（H5）

**其它需要 Reviewer 或社区知晓的内容：**
