### PR TITLE
fix: InfiniteScroll组件complete后reset，若筛选的新数据complete了且未铺满一屏，则status一直是…

### DIFF
--- a/packages/vantui/src/infinite-scroll/README.md
+++ b/packages/vantui/src/infinite-scroll/README.md
@@ -47,7 +47,7 @@ import { InfiniteScroll, VirtualList } from '@antmjs/vantui'
 
 | 方法  | 说明         | 类型                                             |
 | ----- | ------------ | ------------------------------------------------ |
-| reset | 重置加载状态 | _&nbsp;&nbsp;()&nbsp;=>&nbsp;Promise<null><br/>_ |
+| reset | 重置加载状态 | _&nbsp;&nbsp;(loadMore?: boolean)&nbsp;=>&nbsp;Promise<null><br/>_ |
 
 ### 样式变量
 

--- a/packages/vantui/src/infinite-scroll/infinite-scroll.tsx
+++ b/packages/vantui/src/infinite-scroll/infinite-scroll.tsx
@@ -42,10 +42,11 @@ function InfiniteScroll_(
   const thisDom = useRef()
   const [forceKey, setForceKey] = useState(0) // 解决IntersectionObserver中执行loadmore时无法拿到最新的俩是state
 
-  const reset = useCallback((): Promise<null> => {
+  const reset = useCallback((needLoad?: boolean): Promise<null> => {
     return new Promise((resolve) => {
       nextTick(() => {
-        setForceKey(0)
+        if( needLoad ) setForceKey(Date.now())
+        else setForceKey(0)
         setStatus('loading')
         setOnRequest(false)
         resolve(null)

--- a/packages/vantui/types/infinite-scroll.d.ts
+++ b/packages/vantui/types/infinite-scroll.d.ts
@@ -51,8 +51,9 @@ export interface InfiniteScrollProps extends ViewProps {
 export interface InfiniteScrollInstance {
   /**
    * @description 重置加载状态
+   * @param loadMore 是否触发加载方法
    */
-  reset: () => Promise<null>
+  reset: (loadMore?:boolean) => Promise<null>
 }
 
 declare const InfiniteScroll: FunctionComponent<InfiniteScrollProps>


### PR DESCRIPTION
…loading

<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
reset添加传参控制是否触发loadMore

**这个 PR 是什么类型?** (至少选择一个)

- [X] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [X] TypeScript 类型定义修改(Typings)
- [X] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [X] 提交到 main 分支
- [X] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [X] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [X] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] 快手小程序
- [ ] QQ 轻应用
- [ ] Web 平台（H5）

**其它需要 Reviewer 或社区知晓的内容：**

- loadMore由监听进入视窗触发, reset不会触发，导致以下场景status会一直是loading
  - 筛选搜索时需要调用reset，status更改为loading, 搜索的新数据只有2条, 由于不触发loadMore，所以无法更新内部status
  - 筛选搜索的数据两次都为空数组，该场景容易复现bug