### PR TITLE
修复onBeforeRead返回false时，依旧调用onAfterRead上传bug

### DIFF
--- a/packages/vantui/src/uploader/index.tsx
+++ b/packages/vantui/src/uploader/index.tsx
@@ -104,9 +104,8 @@ export function Uploader(props: UploaderProps) {
   const _onBeforeRead = useCallback(
     (event: ITouchEvent) => {
       const { file } = event.detail
-      let res: any = true
       if (useBeforeRead) {
-        res = new Promise((resolve: any, reject: any) => {
+        new Promise((resolve: any, reject: any) => {
           const params = Object.assign(Object.assign({ file }, getDetail()), {
             callback: (ok: boolean) => {
               ok ? resolve() : reject()
@@ -114,19 +113,13 @@ export function Uploader(props: UploaderProps) {
           })
           event.detail = params
           onBeforeRead?.(event)
-        }).catch((err) => {
-          console.log('err: ', err)
-        })
-      }
-      if (!res) {
-        return
-      }
-      if (isPromise(res)) {
-        res.then((data: any) => {
+        }).then((data: any) => {
           event.detail = {
             file: data || file,
           }
           return _onAfterRead(event)
+        }).catch((err) => {
+          console.log('err: ', err)
         })
       } else {
         event.detail = {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)
修复当onBeforeRead校验不通过时，onAfterRead依旧会被调用bug

**这个 PR 是什么类型?** (至少选择一个)

- [ √] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ √] 提交到 main 分支
- [√ ] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [√ ] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [ √] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ √] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] 快手小程序
- [ ] QQ 轻应用
- [ ] Web 平台（H5）

**其它需要 Reviewer 或社区知晓的内容：**
