### PR TITLE
feat:为Uploader增加onClickUpload回调属性

### DIFF
--- a/packages/vantui/src/uploader/README.md
+++ b/packages/vantui/src/uploader/README.md
@@ -78,6 +78,7 @@ import { Uploader } from '@antmjs/vantui'
 | onAfterRead      | -    | _&nbsp;&nbsp;(<br/>&nbsp;&nbsp;&nbsp;&nbsp;event:&nbsp;ITouchEvent<br/>&nbsp;&nbsp;)&nbsp;=>&nbsp;any<br/>_                                                                                                                                                                     | -      | `false` |
 | onOversize       | -    | _&nbsp;&nbsp;(<br/>&nbsp;&nbsp;&nbsp;&nbsp;event:&nbsp;ITouchEvent<br/>&nbsp;&nbsp;)&nbsp;=>&nbsp;any<br/>_                                                                                                                                                                     | -      | `false` |
 | onClickPreview   | -    | _&nbsp;&nbsp;(data:&nbsp;any)&nbsp;=>&nbsp;any<br/>_                                                                                                                                                                                                                            | -      | `false` |
+| onClickUpload    | -    | _&nbsp;&nbsp;(<br/>&nbsp;&nbsp;&nbsp;&nbsp;event:&nbsp;ITouchEvent<br/>&nbsp;&nbsp;)&nbsp;=>&nbsp;any<br/>_                                                                                                                                                                     | -      | `false` |
 
 ### 样式变量
 

--- a/packages/vantui/src/uploader/index.tsx
+++ b/packages/vantui/src/uploader/index.tsx
@@ -47,6 +47,7 @@ export function Uploader(props: UploaderProps) {
     onAfterRead,
     onOversize,
     onClickPreview,
+    onClickUpload,
     style,
     className,
     children,
@@ -140,6 +141,7 @@ export function Uploader(props: UploaderProps) {
   const startUpload = useCallback(
     (event: ITouchEvent) => {
       if (disabled) return
+      onClickUpload?.(event)
       chooseFile({
         accept,
         multiple,
@@ -169,6 +171,7 @@ export function Uploader(props: UploaderProps) {
       maxCount,
       multiple,
       onError,
+      onClickUpload,
       state.lists.length,
       accept,
       camera,

--- a/packages/vantui/types/uploader.d.ts
+++ b/packages/vantui/types/uploader.d.ts
@@ -33,6 +33,7 @@ export interface UploaderProps extends ViewProps {
   onAfterRead?: (event: ITouchEvent) => any
   onOversize?: (event: ITouchEvent) => any
   onClickPreview?: (data: any) => any
+  onClickUpload?: (event: ITouchEvent) => any
 }
 
 declare const Uploader: FunctionComponent<UploaderProps>


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

为 `Uploader` 组件增加 `onClickUpload` 回调属性，在用户点击上传图标时触发回调。

* 缘由1：[VantUI 4](https://vant-ui.github.io/vant/#/zh-CN/uploader) 的 `Uploader` 组件中存在 `click-upload` 回调事件，此次 PR 为 `Uploader` 组件增加同效果的回调属性 `onClickUpload`。
* 缘由2：在进行视频上传的场景中（特别是在企业微信小程序中），拍摄时长为 60s 左右的视频并开启视频压缩 (`compressed`) 时，`Taro.chooseVideo` 方法的 `success` 回调会等待很长时间才会触发，导致用户上传视频后，需要等待很长时间才能够收到 `onBeforeRead` 和 `onAfterRead` 回调；因此，增加一个 `onClickUpload` 回调方法，以解决上述问题。

**这个 PR 是什么类型?** (至少选择一个)

- [ ] 错误修复(Bugfix) issue id #
- [x] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 main 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] 快手小程序
- [ ] QQ 轻应用
- [ ] Web 平台（H5）

**其它需要 Reviewer 或社区知晓的内容：**

暂无。