### PR TITLE
fix: 修复日历组件的日期范围限制错误

### DIFF
--- a/packages/vantui/src/calendar/index.tsx
+++ b/packages/vantui/src/calendar/index.tsx
@@ -137,11 +137,11 @@ function Index(
         const start = limitDateRange(
           startDay || now,
           minDate,
-          getPrevDay(new Date(maxDate)).getTime(),
+          allowSameDay ? maxDate : getPrevDay(maxDate).getTime(),
         )
         const end = limitDateRange(
           endDay || now,
-          getNextDay(new Date(minDate)).getTime(),
+          allowSameDay ? minDate : getNextDay(minDate).getTime(),
         )
         return [start, end]
       }
@@ -156,7 +156,7 @@ function Index(
       }
       return limitDateRange(defaultDate)
     },
-    [limitDateRange, maxDate, minDate, type],
+    [limitDateRange, allowSameDay, maxDate, minDate, type],
   )
 
   const scrollIntoViewCompatible = useCallback((t) => {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ ] 提交到 main 分支
- [ ] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [ ] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [ ] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] 快手小程序
- [ ] QQ 轻应用
- [ ] Web 平台（H5）

**其它需要 Reviewer 或社区知晓的内容：**

日历组件开启 `allowSameDay`  开始结束日期无法默认选中同一日期
