### PR TITLE
docs: 新增官方文档点击可以复制icon功能。

### DIFF
--- a/packages/vantui/src/icon/demo/demo2.tsx
+++ b/packages/vantui/src/icon/demo/demo2.tsx
@@ -1,6 +1,7 @@
 import { Text } from '@tarojs/components'
 import icons from '@vant/icons'
 import { Col, Icon } from '@antmjs/vantui'
+import * as computed from '../wxs'
 
 export default function Demo() {
   return (
@@ -10,6 +11,7 @@ export default function Demo() {
           key={i}
           span="6"
           style={{ paddingTop: '20px', paddingBottom: '20px' }}
+          onClick={() => computed.copyIcon(name)}
         >
           <Icon name={name} size="32px" />
           <Text>{name}</Text>

--- a/packages/vantui/src/icon/demo/demo3.tsx
+++ b/packages/vantui/src/icon/demo/demo3.tsx
@@ -1,6 +1,7 @@
 import { Text } from '@tarojs/components'
 import icons from '@vant/icons'
 import { Col, Icon } from '@antmjs/vantui'
+import * as computed from '../wxs'
 
 export default function Demo() {
   return (
@@ -10,6 +11,7 @@ export default function Demo() {
           key={i}
           span="6"
           style={{ paddingTop: '20px', paddingBottom: '20px', height: '100px' }}
+          onClick={() => computed.copyIcon(name)}
         >
           <Icon name={name} size="32px" />
           <Text style={{ textAlign: 'center' }}>{name}</Text>

--- a/packages/vantui/src/icon/demo/demo4.tsx
+++ b/packages/vantui/src/icon/demo/demo4.tsx
@@ -1,6 +1,7 @@
 import { Text } from '@tarojs/components'
 import icons from '@vant/icons'
 import { Col, Icon } from '@antmjs/vantui'
+import * as computed from '../wxs'
 
 export default function Demo() {
   return (
@@ -10,6 +11,7 @@ export default function Demo() {
           key={i}
           span="6"
           style={{ paddingTop: '20px', paddingBottom: '20px', height: '100px' }}
+          onClick={() => computed.copyIcon(name)}
         >
           <Icon name={name} size="32px" />
           <Text style={{ textAlign: 'center' }}>{name}</Text>

--- a/packages/vantui/src/icon/wxs.ts
+++ b/packages/vantui/src/icon/wxs.ts
@@ -1,3 +1,4 @@
+import Taro from '@tarojs/taro'
 import { style } from '../wxs/style'
 import { addUnit } from '../wxs/add-unit'
 
@@ -33,4 +34,17 @@ function rootStyle(data: any) {
   ])
 }
 
-export { isImage, rootClass, rootStyle }
+//复制icon
+function copyIcon(name: string) {
+  Taro.setClipboardData({
+    data: `<Icon name='${name}' size="32px" />`,
+    success: () => {
+      Taro.showToast({
+        title: '复制成功',
+        icon: 'none',
+      })
+    },
+  })
+}
+
+export { isImage, rootClass, rootStyle, copyIcon }


### PR DESCRIPTION
**这个 PR 做了什么?** 
官网的icon点击之后可以让开发人员直接复制，而不用手动去写出name和icon组件

**这个 PR 是什么类型?** (至少选择一个)
- [ ] 错误修复(Bugfix) issue id #
- [ √] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ √] 提交到 main 分支
- [ √] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [√ ] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [√ ] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [ ] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] 快手小程序
- [ ] QQ 轻应用
- [ ] Web 平台（H5）

**其它需要 Reviewer 或社区知晓的内容：**
