### PR TITLE
fix: 修复签名组件在微信基础库3.7.8的兼容性问题

### DIFF
--- a/packages/vantui/src/signature/index.tsx
+++ b/packages/vantui/src/signature/index.tsx
@@ -82,40 +82,42 @@ const Signature = forwardRef(function Signature(
     return new Promise((resolve, reject) => {
       const base64 = ctx.current?.canvas?.toDataURL(`image/${props.type}`, 0.8)
 
-      Taro.createSelectorQuery()
-        .select(`#${canvasId}${compIndex}`)
-        .fields({
-          node: true,
-          size: true,
-        })
-        .exec((res) => {
-          if (
-            process.env.NODE_ENV === 'development' &&
-            ['alipay', 'tt', 'swan', 'kwai', 'dd'].includes(
-              process.env.TARO_ENV,
-            )
-          ) {
-            console.warn(
-              `@anmjs/vantui: signature组件调用了canvasToTempFilePath， 当前IDE不支持调试，须在真机上调试`,
-            )
-          }
-          Taro.canvasToTempFilePath({
-            canvas: res[0].node,
-            fileType: props.type,
-            canvasId: `${canvasId}${compIndex}`,
-            success: (res) => {
-              resolve({
-                tempFilePath: res.tempFilePath,
-                base64: base64,
-                canvas: ctx.current?.canvas,
-              })
-            },
-            fail: (err) => {
-              console.error(`@anmjs/vantui: signature 转换图片失败:`, err)
-              reject(err)
-            },
+      base64ToFile(base64 as string)
+        .then((filePath) => {
+          resolve({
+            tempFilePath: filePath,
+            base64: base64,
+            canvas: ctx.current?.canvas,
           })
         })
+        .catch((err) => {
+          console.error(`@anmjs/vantui: signature 转换图片失败:`, err)
+          reject(err)
+        })
+    })
+  }
+
+  const base64ToFile = (base64: string) : Promise<string> => {
+    return new Promise((resolve, reject) => {
+      const data = base64.replace(/^data:image\/\w+;base64,/, '')
+      const buffer = Taro.base64ToArrayBuffer(data)
+      const randomFileName = `${Date.now()}-${Math.random()
+        .toString(36)
+        .slice(2)}.png`
+      const filePath = `${Taro.env.USER_DATA_PATH}/${randomFileName}`
+
+      Taro.getFileSystemManager().writeFile({
+        filePath,
+        data: buffer,
+        encoding: 'binary',
+        success: () => {
+          resolve(filePath)
+        },
+        fail: (err) => {
+          console.error('@anmjs/vantui: signature failed to save file: ', err);
+          reject(err)
+        },
+      })
     })
   }
 


### PR DESCRIPTION
canvasToTempFilePath 接口在微信基础库3.7.8上抛出异常，导致签名组件不可用，改用 base64 + base64ToArrayBuffer 接口实现。

参考：
https://developers.weixin.qq.com/community/develop/doc/0008022ea30318366fe25b3596b800

<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 main 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] 快手小程序
- [ ] QQ 轻应用
- [ ] Web 平台（H5）

**其它需要 Reviewer 或社区知晓的内容：**
