### PR TITLE
fix(calendar): 修复日历组件的 catchMove 属性处理

### DIFF
--- a/packages/vantui/src/calendar/index.tsx
+++ b/packages/vantui/src/calendar/index.tsx
@@ -499,7 +499,7 @@ function Index(
         className={`van-calendar ${className || ''}`}
         style={utils.style([style])}
         // @ts-ignore
-        catchMove
+        catchMove={poppable}
         {...others}
       >
         {longspan && longSpanShow && poppable && (
@@ -592,7 +592,7 @@ function Index(
 
   return (
     // @ts-ignore
-    <View catchMove>
+    <View catchMove={poppable}>
       {poppable ? (
         <VanPopup
           className={'van-calendar__popup--' + position}


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

 将 catchMove 属性的值从直接使用变为根据 poppable 属性动态设置，避免开启平铺属性时，会阻碍页面滚动的问题

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ ] 提交到 main 分支
- [ ] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [ ] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] 快手小程序
- [ ] QQ 轻应用
- [x] Web 平台（H5）

**其它需要 Reviewer 或社区知晓的内容：**

在平铺的日历组件上拖动页面会被阻塞，官网demo上即可复现
![image](https://github.com/user-attachments/assets/f63daf7a-b709-4dcc-9cc8-a6ac0ca59e36)

