### PR TITLE
fix(swiper): 修复 Swiper 组件在两个 item 时的 onChange 和 指示器样式错误问题

### DIFF
--- a/packages/vantui/src/swiper-item/index.tsx
+++ b/packages/vantui/src/swiper-item/index.tsx
@@ -11,7 +11,7 @@ export const SwiperItem = (props: SwiperItemProps) => {
   }
 
   return (
-    <View className={`van-swiper-item ${className}`} {...others}>
+    <View className={`van-swiper-item ${className || ''}`} {...others}>
       {children}
     </View>
   )

--- a/packages/vantui/src/swiper/swiper.tsx
+++ b/packages/vantui/src/swiper/swiper.tsx
@@ -110,7 +110,7 @@ const Swiper = (
     return isVertical ? H : W
   }, [H, W, isVertical])
 
-  const { childs, childCount, resetChilds } = useMemo(() => {
+  const { childs, childCount, pageCount, resetChilds } = useMemo(() => {
     let childCount = 0
     const childFirst = children?.[0]
     const childs =
@@ -123,6 +123,7 @@ const Swiper = (
     const resetChilds = [...childs]
 
     const childLast = children?.[childCount - 1]
+    const pageCount = childCount === 2 ? 2 : childCount
     if (childCount === 2) {
       if (childFirst) {
         resetChilds.push(childFirst)
@@ -135,9 +136,11 @@ const Swiper = (
       }
       childCount += 1
     }
+
     return {
       childs,
       childCount,
+      pageCount,
       resetChilds,
     }
   }, [children])
@@ -344,8 +347,8 @@ const Swiper = (
   }))
 
   useEffect(() => {
-    onChange?.(active)
-  }, [active, onChange])
+    onChange?.((active + pageCount) % pageCount)
+  }, [active, pageCount, onChange])
 
   useDidShow(() => {
     setShowToDo(true)
@@ -451,7 +454,7 @@ const Swiper = (
             return (
               <Text
                 style={
-                  (active + childCount) % childCount === index
+                  (active + pageCount) % pageCount === index
                     ? {
                         backgroundColor: paginationColor,
                       }
@@ -459,7 +462,7 @@ const Swiper = (
                 }
                 className={classNames({
                   ['van-swiper__pagination-item']: true,
-                  active: (active + childCount) % childCount === index,
+                  active: (active + pageCount) % pageCount === index,
                 })}
                 key={index}
               />


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

- 修复 Swiper 组件在两个 item 时的 onChange 和 指示器样式错误问题
- 优化 SwiperItem 组件中 className 的 undefined 空值

有两张图片时，onChange返回的值有 0 1 2 3，且下面的指示器在 2 3 时没有选中

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [x] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [ ] 提交到 main 分支
- [ ] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [ ] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] 快手小程序
- [ ] QQ 轻应用
- [x] Web 平台（H5）

**其它需要 Reviewer 或社区知晓的内容：**
