### PR TITLE
fix(button): 修复 Button 组件错误清理 Toast 的 bug

### DIFF
--- a/packages/vantui/src/button/index.tsx
+++ b/packages/vantui/src/button/index.tsx
@@ -56,7 +56,9 @@ function Button(props: ButtonProps) {
   }, [loading])
 
   useEffect(() => {
-    if (innerLoading && loadingMode === 'toast') {
+    if (loadingMode !== 'toast') return
+
+    if (innerLoading) {
       Toast.loading({
         selector: `#${toastId}`,
         duration: 60 * 60,
@@ -68,7 +70,7 @@ function Button(props: ButtonProps) {
       Toast.clear()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [innerLoading])
+  }, [innerLoading, loadingMode])
 
   const _click = useCallback(
     (e) => {


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

修复 Button 组件在 loadingMode 不是 toast 的情况下，loading 属性更新时会清理Toast 实例的问题

- 在 useEffect 中增加对 loadingMode 的判断，避免非 toast 模式下会清理任意 Toast 实例
- 更新 useEffect 的依赖项，确保在 loadingMode 或 innerLoading 变化时重新执行效果

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 main 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] 快手小程序
- [x] QQ 轻应用
- [x] Web 平台（H5）

**其它需要 Reviewer 或社区知晓的内容：**
