### PR TITLE
fix(toast): 补全 Toast 的默认配置相关功能

### DIFF
--- a/packages/vantui/src/toast/README.md
+++ b/packages/vantui/src/toast/README.md
@@ -77,7 +77,7 @@ Toast.show({
 | fail | 展示失败提示 | _&nbsp;&nbsp;(<br/>&nbsp;&nbsp;&nbsp;&nbsp;options:<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&brvbar;&nbsp;ToastProps<br/>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&brvbar;&nbsp;string<br/>&nbsp;&nbsp;)&nbsp;=>&nbsp;any<br/>_ | - | `true` |
 | clear | 关闭提示 | _&nbsp;&nbsp;(<br/>&nbsp;&nbsp;&nbsp;&nbsp;options?:&nbsp;ToastProps<br/>&nbsp;&nbsp;)&nbsp;=>&nbsp;void<br/>_ | - | `true` |
 | setDefaultOptions | 修改默认配置，对所有 Toast 生效。传入 type 可以修改指定类型的默认配置 | _&nbsp;&nbsp;(<br/>&nbsp;&nbsp;&nbsp;&nbsp;options:&nbsp;ToastProps<br/>&nbsp;&nbsp;)&nbsp;=>&nbsp;void<br/>_ | - | `true` |
-| resetDefaultOptions | 重置默认配置，对所有 Toast 生效。传入 type 可以重置指定类型的默认配置 | _&nbsp;&nbsp;(<br/>&nbsp;&nbsp;&nbsp;&nbsp;options:&nbsp;any<br/>&nbsp;&nbsp;)&nbsp;=>&nbsp;void<br/>_ | - | `true` |
+| resetDefaultOptions | 重置默认配置，对所有 Toast 生效。 | _&nbsp;&nbsp;()&nbsp;=>&nbsp;void<br/>_ | - | `true` |
 | createOnlyToast | 获取唯一的 toast 组件，不需要手动设置 id 和 selector | _&nbsp;&nbsp;()&nbsp;=>&nbsp;FunctionComponent<ToastProps>&nbsp;&<br/>&nbsp;&nbsp;&nbsp;&nbsp;toastProps<br/>_ | - | `true` |
 
 ### 样式变量

--- a/packages/vantui/src/toast/events.tsx
+++ b/packages/vantui/src/toast/events.tsx
@@ -1,3 +1,4 @@
+import _assign from 'lodash/assign'
 import { ToastProps } from '../../types/toast'
 import VanOverlay from '../overlay/index'
 import { createExtraNode, ExtraNode } from '../wxs/extra-node'
@@ -8,6 +9,20 @@ const overlayNode: ExtraNode = createExtraNode()
 const defaultDuration = 2500
 let timer: NodeJS.Timeout | null = null
 let hasMask = false
+
+const defaultToastOptions: ToastProps = {
+  duration: 2500,
+}
+
+let _defaultOptions = { ...defaultToastOptions }
+
+export function setDefaultOptions(options: ToastProps) {
+  _assign(_defaultOptions, options)
+}
+
+export function resetDefaultOptions() {
+  _defaultOptions = { ...defaultToastOptions }
+}
 
 export function show_(options: ToastProps) {
   if (timer) {
@@ -24,12 +39,12 @@ export function show_(options: ToastProps) {
       ></VanOverlay>,
     )
   }
-  extraNode.renderNode?.(<Toast {...options} />)
+  extraNode.renderNode?.(<Toast {...{ ..._defaultOptions, ...options }} />)
   if (options.duration !== 0) {
     timer = setTimeout(() => {
       clear()
       options?.onClose?.()
-    }, options.duration || defaultDuration)
+    }, options.duration || _defaultOptions?.duration || defaultDuration)
   }
 }
 

--- a/packages/vantui/src/toast/index.tsx
+++ b/packages/vantui/src/toast/index.tsx
@@ -1,6 +1,14 @@
 import { ToastProps } from '../../types/toast'
 import { createOnlyToast } from './create-only-toast'
-import { success, loading, fail, clear, show } from './events'
+import {
+  success,
+  loading,
+  fail,
+  clear,
+  show,
+  setDefaultOptions,
+  resetDefaultOptions,
+} from './events'
 
 // @ts-ignore
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -13,6 +21,8 @@ Toast.loading = loading
 Toast.fail = fail
 Toast.clear = clear
 Toast.show = show
+Toast.setDefaultOptions = setDefaultOptions
+Toast.resetDefaultOptions = resetDefaultOptions
 Toast.createOnlyToast = () => createOnlyToast(Toast)
 
 export { Toast }

--- a/packages/vantui/types/toast.d.ts
+++ b/packages/vantui/types/toast.d.ts
@@ -89,9 +89,9 @@ export interface toastProps {
    */
   setDefaultOptions: (options: ToastProps) => void
   /**
-   * @description 重置默认配置，对所有 Toast 生效。传入 type 可以重置指定类型的默认配置
+   * @description 重置默认配置，对所有 Toast 生效。
    */
-  resetDefaultOptions: (options: any) => void
+  resetDefaultOptions: () => void
   /**
    * @description 获取唯一的toast组件，不需要手动设置id和selector
    */


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

- 补全 Toast 组件的默认配置相关功能  #730 
- 更新相关类型定义和文档说明

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [x] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 main 分支
- [ ] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [ ] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [ ] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] 快手小程序
- [x] QQ 轻应用
- [x] Web 平台（H5）

**其它需要 Reviewer 或社区知晓的内容：**

目前是模仿 vant-weapp 的实现，我不确定是否应该通过 @antmjs/vantui 的 DefaultProps 提供的 set 方法来实现。
