### PR TITLE
refactor(utils): 对微信小程序 getSystemInfoSync API的废弃兜底

### DIFF
--- a/packages/vantui/src/common/utils.ts
+++ b/packages/vantui/src/common/utils.ts
@@ -1,5 +1,6 @@
 import Taro, {
   getSystemInfoSync as TaroGetSystemInfoSync,
+  getWindowInfo as TaroGetWindowInfo,
   createSelectorQuery,
 } from '@tarojs/taro'
 import * as raf from 'raf'
@@ -23,6 +24,13 @@ let systemInfo: any
 export function getSystemInfoSync() {
   systemInfo = TaroGetSystemInfoSync()
   return systemInfo
+}
+
+let windowInfo: any
+export function getWindowInfo() {
+  windowInfo =
+    process.env.TARO_ENV === 'weapp' ? TaroGetWindowInfo() : getSystemInfoSync()
+  return windowInfo
 }
 
 let menuInfo: any

--- a/packages/vantui/src/common/version.ts
+++ b/packages/vantui/src/common/version.ts
@@ -1,7 +1,8 @@
 import Taro, {
-  getSystemInfoSync as TaroGetSystemInfoSync,
   canIUse,
+  getAppBaseInfo as TaroGetAppBaseInfo,
 } from '@tarojs/taro'
+import { getSystemInfoSync } from './utils'
 function compareVersion(v1: any, v2: any) {
   v1 = v1.split('.')
   v2 = v2.split('.')
@@ -24,15 +25,9 @@ function compareVersion(v1: any, v2: any) {
   }
   return 0
 }
-let systemInfo: any
-function getSystemInfoSync() {
-  if (systemInfo == null) {
-    systemInfo = TaroGetSystemInfoSync()
-  }
-  return systemInfo
-}
 function gte(version: any) {
-  const system = getSystemInfoSync()
+  const system =
+    process.env.TARO_ENV === 'weapp' ? TaroGetAppBaseInfo : getSystemInfoSync()
   return compareVersion(system.SDKVersion || system.version, version) >= 0
 }
 export function canIUseModel() {

--- a/packages/vantui/src/dropdown-item/index.tsx
+++ b/packages/vantui/src/dropdown-item/index.tsx
@@ -8,7 +8,7 @@ import {
   memo,
 } from 'react'
 import { nextTick, usePageScroll } from '@tarojs/taro'
-import { getSystemInfoSync, requestAnimationFrame } from '../common/utils'
+import { getWindowInfo, requestAnimationFrame } from '../common/utils'
 import {
   DropdownItemProps,
   IDropdownItemInstance,
@@ -86,7 +86,7 @@ function Index(
       }
 
       if (parentInstance.direction === 'down') {
-        const winHeight = getSystemInfoSync().windowHeight
+        const winHeight = getWindowInfo().windowHeight
         const bottom = winHeight - rect.top
         wrapperStyle.bottom = -rect.height + 'PX'
         wrapperStyle.height = bottom + 'PX'

--- a/packages/vantui/src/image-cropper/index.tsx
+++ b/packages/vantui/src/image-cropper/index.tsx
@@ -1,7 +1,7 @@
 import { Canvas, Image, View } from '@tarojs/components'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import {
-  getSystemInfoSync,
+  getWindowInfo,
   showLoading,
   hideLoading,
   getImageInfo,
@@ -22,7 +22,7 @@ const pageRects = {
   windowHeight: 0,
   pixelRatio: 1,
 }
-const res = getSystemInfoSync()
+const res = getWindowInfo()
 const { windowWidth, windowHeight, pixelRatio } = res
 pageRects.windowWidth = windowWidth
 pageRects.windowHeight = windowHeight

--- a/packages/vantui/src/mini-nav-bar/index.tsx
+++ b/packages/vantui/src/mini-nav-bar/index.tsx
@@ -3,10 +3,7 @@ import { useState, useEffect, useCallback, useMemo } from 'react'
 import { View } from '@tarojs/components'
 import * as utils from '../wxs/utils'
 import { Icon } from '../icon'
-import {
-  getSystemInfoSync,
-  getMenuButtonBoundingClientRect,
-} from '../common/utils'
+import { getWindowInfo, getMenuButtonBoundingClientRect } from '../common/utils'
 import { MiniNavBarProps } from '../../types/mini-nav-bar'
 import * as computed from './wxs'
 
@@ -66,7 +63,7 @@ export function MiniNavBar(props: MiniNavBarProps) {
   }, [homeUrl])
 
   useEffect(() => {
-    const sysInfo = getSystemInfoSync()
+    const sysInfo = getWindowInfo()
     const menuInfo = getMenuButtonBoundingClientRect()
     if (sysInfo && menuInfo) {
       setState({

--- a/packages/vantui/src/nav-bar/index.tsx
+++ b/packages/vantui/src/nav-bar/index.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react'
 import { View } from '@tarojs/components'
 import * as utils from '../wxs/utils'
-import { getSystemInfoSync } from '../common/utils'
+import { getWindowInfo } from '../common/utils'
 import { NavBarProps } from '../../types/nav-bar'
 import { Icon } from '../icon'
 import { get } from '../default-props'
@@ -33,7 +33,7 @@ export function NavBar(props: NavBarProps) {
   }
 
   const statusBarHeight = useMemo(() => {
-    const { statusBarHeight: _statusBarHeight } = getSystemInfoSync()
+    const { statusBarHeight: _statusBarHeight } = getWindowInfo()
     if (isNaN(_statusBarHeight)) {
       return 22
     }

--- a/packages/vantui/src/notify/notify.tsx
+++ b/packages/vantui/src/notify/notify.tsx
@@ -4,7 +4,7 @@ import { nextTick } from '@tarojs/taro'
 import * as utils from '../wxs/utils'
 import { NotifyProps } from '../../types/notify'
 import VanTransition from '../transition/index'
-import { getSystemInfoSync } from '../common/utils'
+import { getWindowInfo } from '../common/utils'
 import { get } from '../default-props'
 import * as computed from './wxs'
 
@@ -68,7 +68,7 @@ export function Notify(props: NotifyProps) {
 
   useEffect(() => {
     nextTick(() => {
-      const { statusBarHeight } = getSystemInfoSync()
+      const { statusBarHeight } = getWindowInfo()
       setState((state) => {
         return {
           ...state,

--- a/packages/vantui/src/water-mark/utils.ts
+++ b/packages/vantui/src/water-mark/utils.ts
@@ -1,4 +1,5 @@
-import { createSelectorQuery, getSystemInfo } from '@tarojs/taro'
+import { createSelectorQuery } from '@tarojs/taro'
+import { getWindowInfo } from '../common/utils'
 
 export function getCanvas(compIndex) {
   return new Promise((resolve) => {
@@ -35,7 +36,7 @@ export function getWaterData({
 }): Promise<string> {
   return new Promise(async (resolve) => {
     const ctx = canvas.getContext('2d')
-    const ratio = (await getSystemInfo()).pixelRatio
+    const ratio = getWindowInfo().pixelRatio
     const canvasWidth = `${(gapX + width) * ratio}px`
     const canvasHeight = `${(gapY + height) * ratio}px`
 


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

- 新增 getWindowInfo 方法，用于获取窗口信息
- 更新 SDKversion 和 version 的获取方式
- 更新相关组件中获取窗口信息的方式，使用新的 getWindowInfo 方法

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #748
- [ ] 新功能(Feature)
- [x] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 main 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] 快手小程序
- [ ] QQ 轻应用
- [ ] Web 平台（H5）

**其它需要 Reviewer 或社区知晓的内容：**

微信小程序开发工具一直报 getSystemInfoSync 这个API废弃。
不过除了支付宝小程序，目前我查到的几个小程序都没有微信小程序提供的`getWindowInfo`等替代`getSystemInfoSync`的 API。而 Taro 框架层面是直接替换 `Taro.xxx`为 `wx.xxx`  `my.xxx` 的，目前能想到的解决方式是只对`微信小程序`的`getSystemInfoSync`做单独处理。 不知道有没有更合适的处理方法

