### PR TITLE
fix(uploader): 不再使用过时的chooseImage和chooseVideo方法

### DIFF
--- a/packages/vantui/src/uploader/utils.ts
+++ b/packages/vantui/src/uploader/utils.ts
@@ -94,11 +94,14 @@ export function chooseFile({
   return new Promise((resolve, reject) => {
     switch (accept) {
       case 'image':
-        chooseImage({
+        chooseMedia({
           count: multiple ? Math.min(maxCount, 9) : 1,
+          mediaType: ['image'],
           sourceType: capture || ['album', 'camera'],
+          maxDuration,
           sizeType: sizeType || ['original', 'compressed'],
-          success: (res) => resolve(formatImage(res)),
+          camera: camera || 'back',
+          success: (res) => resolve(formatMedia(res)),
           fail: reject,
         })
         break
@@ -114,12 +117,16 @@ export function chooseFile({
         })
         break
       case 'video':
-        chooseVideo({
+        chooseMedia({
+          count: multiple ? Math.min(maxCount, 9) : 1,
+          mediaType: ['video'],
           sourceType: capture || ['album', 'camera'],
-          compressed,
-          maxDuration: maxDuration || 60,
+          maxDuration,
+          sizeType: compressed
+            ? ['compressed']
+            : sizeType || ['original', 'compressed'],
           camera: camera || 'back',
-          success: (res) => resolve(formatVideo(res)),
+          success: (res) => resolve(formatMedia(res)),
           fail: reject,
         })
         break


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

#741 微信已将wx.chooseVideo和wx.chooseImage标记为停止维护, 并建议使用wx.chooseMedia替代

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id #
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 main 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [ ] 支付宝小程序
- [ ] 百度小程序
- [ ] 头条小程序
- [ ] 快手小程序
- [ ] QQ 轻应用
- [ ] Web 平台（H5）

**其它需要 Reviewer 或社区知晓的内容：**
