### PR TITLE
fix(swiper): 修复双项目循环模式下的分页和切换问题 (#797)

### DIFF
--- a/packages/vantui/src/swiper/swiper.tsx
+++ b/packages/vantui/src/swiper/swiper.tsx
@@ -78,6 +78,44 @@ const Swiper = (
     containerSize,
     ...rest
   } = propSwiper
+
+  const { childs, childCount, pageCount, resetChilds } = useMemo(() => {
+    let childCount = 0
+    const childFirst = children?.[0]
+    const childs =
+      Children.map(children, (child) => {
+        if (!isValidElement(child)) return null
+        childCount++
+        return child
+      }) || []
+
+    const resetChilds = [...childs]
+
+    const childLast = children?.[childCount - 1]
+    const pageCount = childCount === 2 ? 2 : childCount
+    // 2 items loop, duplicate to 4 items: [2, 1, 2, 1]
+    // Indices: 0(2), 1(1), 2(2), 3(1)
+    if (childCount === 2 && loop) {
+      if (childFirst) {
+        resetChilds.push(childFirst)
+      }
+
+      childCount += 1
+
+      if (childLast) {
+        resetChilds.unshift(childLast)
+      }
+      childCount += 1
+    }
+
+    return {
+      childs,
+      childCount,
+      pageCount,
+      resetChilds,
+    }
+  }, [children, loop])
+
   const isVertical = direction === 'vertical'
   const timer = useRef<any>(null)
   const containerRef = useRef<any>(null)
@@ -85,9 +123,14 @@ const Swiper = (
   const [refRandomId] = useState(Math.random().toString(36).slice(-8))
   const [moving, setmoving] = useState(false)
   // eslint-disable-next-line prefer-const
-  let [active, setActive_] = useState(
-    typeof initPage === 'number' ? initPage : 0,
-  )
+  let [active, setActive_] = useState(() => {
+    let init = typeof initPage === 'number' ? initPage : 0
+    if (resetChilds.length === 4 && pageCount === 2) {
+      init += 1
+    }
+    return init
+  })
+
   const setActive = (a) => {
     active = a
     setActive_(a)
@@ -109,41 +152,6 @@ const Swiper = (
   const size = useMemo(() => {
     return isVertical ? H : W
   }, [H, W, isVertical])
-
-  const { childs, childCount, pageCount, resetChilds } = useMemo(() => {
-    let childCount = 0
-    const childFirst = children?.[0]
-    const childs =
-      Children.map(children, (child) => {
-        if (!isValidElement(child)) return null
-        childCount++
-        return child
-      }) || []
-
-    const resetChilds = [...childs]
-
-    const childLast = children?.[childCount - 1]
-    const pageCount = childCount === 2 ? 2 : childCount
-    if (childCount === 2) {
-      if (childFirst) {
-        resetChilds.push(childFirst)
-      }
-
-      childCount += 1
-
-      if (childLast) {
-        resetChilds.unshift(childLast)
-      }
-      childCount += 1
-    }
-
-    return {
-      childs,
-      childCount,
-      pageCount,
-      resetChilds,
-    }
-  }, [children])
 
   // 重置 全部位移信息
   const touchReset = useCallback(() => {
@@ -269,19 +277,42 @@ const Swiper = (
     let _duration = duration
     let timeout: any = 0
     // 第一张和最后一样的特殊情况
-    if (active === 0 && activeNew === childCount - 1) {
-      _duration = 0
-      timeout = duration || 0 + 16.66
-      setInnertStyle(active, duration, size)
-    } else if (active === childCount - 1 && activeNew === 0) {
-      _duration = 0
-      timeout = duration || 0 + 16.66
-      setInnertStyle(active, duration, -childCount * size)
+    const is2ItemLoop = resetChilds.length === 4 && pageCount === 2
+    let needReset = false
+    if (is2ItemLoop) {
+      if (active === 2 && activeNew === 3) {
+        needReset = true
+        timeout = duration
+        setInnertStyle(activeNew, duration)
+      } else if (active === 1 && activeNew === 0) {
+        needReset = true
+        timeout = duration
+        setInnertStyle(activeNew, duration)
+      }
+    }
+
+    if (!needReset) {
+      if (active === 0 && activeNew === childCount - 1) {
+        _duration = 0
+        timeout = duration || 0 + 16.66
+        setInnertStyle(active, duration, size)
+      } else if (active === childCount - 1 && activeNew === 0) {
+        _duration = 0
+        timeout = duration || 0 + 16.66
+        setInnertStyle(active, duration, -childCount * size)
+      }
     }
     setTimeout(() => {
       setmoving(false)
-      setActive(activeNew)
-      setInnertStyle(activeNew, _duration)
+      let finalActive = activeNew
+      // For 2 items loop, we expanded to 4 items [2, 1, 2, 1]
+      // Indices 1 and 2 are the stable ones. 0 and 3 are clones.
+      if (resetChilds.length === 4 && pageCount === 2) {
+        if (activeNew === 0) finalActive = 2
+        if (activeNew === 3) finalActive = 1
+      }
+      setActive(finalActive)
+      setInnertStyle(finalActive, activeNew !== finalActive ? 0 : _duration)
       callback?.()
     }, timeout)
   }
@@ -343,14 +374,28 @@ const Swiper = (
   )
 
   useImperativeHandle(ref, () => ({
-    to: (n) => moveTo(n),
+    to: (n) => {
+      let target = n
+      if (resetChilds.length === 4 && pageCount === 2) {
+        target = n + 1
+      }
+      moveTo(target)
+    },
     prev: () => moveTo(active - 1 < 0 ? childCount - 1 : active - 1),
     next: () => moveTo(active + 1 > childCount - 1 ? 0 : active + 1),
   }))
 
+  const getCurrentPage = useCallback(() => {
+    let reportIndex = (active + pageCount) % pageCount
+    if (resetChilds.length === 4 && pageCount === 2) {
+      reportIndex = (active - 1 + pageCount) % pageCount
+    }
+    return reportIndex
+  }, [active, pageCount, resetChilds.length])
+
   useEffect(() => {
-    onChange?.((active + pageCount) % pageCount)
-  }, [active, pageCount, onChange])
+    onChange?.(getCurrentPage())
+  }, [getCurrentPage, onChange])
 
   useDidShow(() => {
     setShowToDo(true)
@@ -456,7 +501,7 @@ const Swiper = (
             return (
               <Text
                 style={
-                  (active + pageCount) % pageCount === index
+                  getCurrentPage() === index
                     ? {
                         backgroundColor: paginationColor,
                       }
@@ -464,7 +509,7 @@ const Swiper = (
                 }
                 className={classNames({
                   ['van-swiper__pagination-item']: true,
-                  active: (active + pageCount) % pageCount === index,
+                  active: getCurrentPage() === index,
                 })}
                 key={index}
               />


### PR DESCRIPTION
<!--
请务必阅读贡献者指南:
https://github.com/NervJS/taro/blob/master/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**这个 PR 做了什么?** (简要描述所做更改)

修复当 loop 为 true 且只有 2 个项目时的特殊处理逻辑：
1. 将 2 个项目扩展为 4 个 [2,1,2,1] 以实现循环效果
2. 修正分页指示器和切换时的索引计算
3. 优化 moveTo 和 getCurrentPage 的逻辑处理

**这个 PR 是什么类型?** (至少选择一个)

- [x] 错误修复(Bugfix) issue id fixes #797
- [ ] 新功能(Feature)
- [ ] 代码重构(Refactor)
- [ ] TypeScript 类型定义修改(Typings)
- [ ] 文档修改(Docs)
- [ ] 代码风格更新(Code style update)
- [ ] 其他，请描述(Other, please describe):

**这个 PR 满足以下需求:**

- [x] 提交到 main 分支
- [x] Commit 信息遵循 [Angular Style Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153)
- [x] 代码遵循相关包中的 .eslintrc, .tslintrc, .stylelintrc 所规定的规范
- [x] 在本地测试可用，不会影响到其它功能

**这个 PR 涉及以下平台:**

- [x] 微信小程序
- [x] 支付宝小程序
- [x] 百度小程序
- [x] 头条小程序
- [x] 快手小程序
- [x] QQ 轻应用
- [x] Web 平台（H5）

**其它需要 Reviewer 或社区知晓的内容：**
